### PR TITLE
main.rs: fix build issue caused by reqwests crate.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn write_files(board: boards::Board, disk: PathBuf, steps: u32)
 		//println!("  GET {} {:?} to write at {}", url, filename, offset);
 
 		// Download file per manifest
-		let mut resp = reqwest::get(url.clone())?;
+		let mut resp = reqwest::get(url.as_str())?;
 		if !resp.status().is_success() {
 			return Err(From::from(format!("Error obtaining {}", url)));
 		}
@@ -152,7 +152,7 @@ fn place_files(board: boards::Board, target_fs: &mut fatfs::FileSystem, steps: u
 		//println!("  GET {} {:?}", url, filename);
 
 		// Download file per manifest
-		let mut resp = reqwest::get(url.clone())?;
+		let mut resp = reqwest::get(url.as_str())?;
 		if !resp.status().is_success() {
 			return Err(From::from(format!("Error obtaining {}", i)));
 		}


### PR DESCRIPTION
Building rune with the latest version of the reqwests crate fails due to the Url type not implementing the 'PolyfillTryInto' trait. But a borrowed string slice implements this trait so this can be used to fix the build instead.