### PR TITLE
Don't hardcode manifest URL in two places

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rune"
 version = "0.1.2"
-edition = "2018"
+edition = "2021"
 authors = ["Alexander von Gluck IV <kallisti5@unixzen.com>"]
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rune"
 version = "0.1.2"
+edition = "2018"
 authors = ["Alexander von Gluck IV <kallisti5@unixzen.com>"]
 license = "MIT"
 

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -57,7 +57,7 @@ pub fn get_arch(arch: String) -> Result<Vec<Board>, Box<dyn Error>> {
 }
 
 pub fn get_board(board_id: String) -> Result<Board, Box<dyn Error>> {
-	let uri = "https://github.com/haiku/firmware/raw/master/u-boot/manifest.json".to_string();
+	let uri = MANIFEST_URI.to_string();
 	let boards = get_boards(uri)?;
 	for i in boards {
 		if i.id == board_id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ mod image_tools;
 fn print_version() {
 	const VERSION: &str = env!("CARGO_PKG_VERSION");
 	println!("Rune v{}", VERSION);
-	println!("Copyright, 2017-2022 Haiku, Inc. All rights reserved.");
+	println!("Copyright, 2017-2024 Haiku, Inc. All rights reserved.");
 	println!("Released under the terms of the MIT license.");
 	println!("Manifest URI: {}", boards::MANIFEST_URI);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use fatfs::{BufStream, FileSystem, FsOptions};
 use getopts::Options;
 use url::Url;
 use indicatif::{ProgressBar,ProgressStyle};
-use partition::Partition;
+use crate::partition::Partition;
 use regex::Regex;
 
 mod boards;


### PR DESCRIPTION
* Don't hardcode manifest URL in two places - do it in one
* Bump Rust edition to 2021 using `cargo fix --edition` in two steps
* Bump copyright year to 2024