### PR TITLE
Try to get better list of boards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rune"
 version = "0.1.2"
+edition = "2021"
 authors = ["Alexander von Gluck IV <kallisti5@unixzen.com>"]
 license = "MIT"
 

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -14,7 +14,7 @@ extern crate curl;
 use std::env;
 use std::error::Error;
 use curl::easy::Easy;
-use fs::File;
+use crate::fs::File;
 
 pub const MANIFEST_URI: &str = "https://github.com/haiku/firmware/raw/master/u-boot/manifest.json";
 

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -27,6 +27,26 @@ pub struct Board {
 	pub files: Vec<String>,
 }
 
+impl Ord for Board {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		(self.id).cmp(&(other.id))
+	}
+}
+
+impl PartialOrd for Board {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl PartialEq for Board {
+	fn eq(&self, other: &Self) -> bool {
+		(self.id) == (other.id)
+	}
+}
+
+impl Eq for Board {}
+
 fn get_boards_local(path: String) -> Result<Vec<Board>, Box<dyn Error>> {
     // Get boards from local manifest
     let file = File::open(path)?;
@@ -60,6 +80,20 @@ pub fn get_boards() -> Result<Vec<Board>, Box<dyn Error>> {
     }
 }
 
+pub fn get_architectures() -> Result<Vec<String>, Box<dyn Error>> {
+	// TODO: this is horrible, we read board file like three times.
+	// Not so bad with local file, but CURLing it three times from Github is a bit... eh
+	let boards = get_boards()?;
+	let mut architectures: Vec<String> = Vec::new();
+	for i in boards {
+		if !architectures.contains(&i.arch) {
+			architectures.push(i.arch);
+		}
+	}
+	architectures.sort();
+	return Ok(architectures)
+}
+
 pub fn get_arch(arch: String) -> Result<Vec<Board>, Box<dyn Error>> {
 	let boards = get_boards()?;
 	let mut results: Vec<Board> = Vec::new();
@@ -68,6 +102,7 @@ pub fn get_arch(arch: String) -> Result<Vec<Board>, Box<dyn Error>> {
 			results.push(i);
 		}
 	}
+	results.sort();
 	return Ok(results)
 }
 
@@ -81,14 +116,29 @@ pub fn get_board(board_id: String) -> Result<Board, Box<dyn Error>> {
 	return Err(From::from("Unknown target board!"));
 }
 
-pub fn print(arch: String) {
-	print!("{}\n===\n", arch);
-	let arch_boards = match get_arch(arch) {
-		Ok(m) => { m },
+pub fn print() {
+	let architectures: Vec<String> = match get_architectures() {
+		Ok(a) => {a},
 		Err(e) => { println!("  Error: {}", e); return },
 	};
+
+	if architectures.len() == 0 {
+		println!("No architectures were found");
+		return
+	}
+
 	print!("  {:20} {:10} {:20}\n", "Board", "SOC", "Name");
-	for board in arch_boards {
-		print!("  {:20} {:10} {:20}\n", board.id, board.soc, board.name);
+	for arch in architectures {
+		// TODO: get list of all architectures, print 
+		let arch_boards = match get_arch(arch.clone()) {
+			Ok(m) => { m },
+			Err(e) => { println!("  Error: {}", e); return },
+		};
+		if arch_boards.len() > 0 {
+			print!("{}\n===\n", arch);
+			for board in arch_boards {
+				print!("  {:20} {:10} {:20}\n", board.id, board.soc, board.name);
+			}
+		}
 	}
 }

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -27,6 +27,7 @@ pub struct Board {
 	pub files: Vec<String>,
 }
 
+// sort boards based on ID only
 impl Ord for Board {
 	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		(self.id).cmp(&(other.id))

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -129,7 +129,6 @@ pub fn print() {
 
 	print!("  {:20} {:10} {:20}\n", "Board", "SOC", "Name");
 	for arch in architectures {
-		// TODO: get list of all architectures, print 
 		let arch_boards = match get_arch(arch.clone()) {
 			Ok(m) => { m },
 			Err(e) => { println!("  Error: {}", e); return },

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,8 +223,7 @@ fn main() {
 		print_version();
 		return;
 	} else if matches.opt_present("l") {
-        //XXX This needs to be better and dynamic!
-		boards::print("arm".to_string());
+		boards::print();
 		process::exit(1);
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use fatfs::{BufStream, FileSystem, FsOptions};
 use getopts::Options;
 use url::Url;
 use indicatif::{ProgressBar,ProgressStyle};
-use partition::Partition;
+use crate::partition::Partition;
 use regex::Regex;
 
 mod boards;


### PR DESCRIPTION
* list is dynamically generated, prints all boards, grouped by architecture, sorted by the board's ID
* move header outside of the architecture loop

example (tested with local crafted JSON file)
```
  Board                SOC        Name                
arm
===
  boneblack            AM335x     BeagleBone Black    
  libre_all_h3         H3         Libre Computer Board ALL-H3-CC
  nanopi_neo           H3         NanoPi Neo          
  odroid_xu3           Exynos5    ODROID XU3/XU4/HC1/HC2
  orangepi_one         H3         OrangePi One        
  rpi2                 BCM2836    Raspberry Pi 2      
  rpi3                 BCM2837    Raspberry Pi 3      
  rpi4                 BCM2711    Raspberry Pi 4      
  tinkerboard          RK3288     Asus Tinkerboard    
arm64
===
  orangepi_zero2       H616       OrangePi Zero2      
weird
===
  weird                weird32    WeirdBoard 3000     
```

I have zero experience with Rust, feel free to make this better :)

- Task defined in https://github.com/haiku/rune/pull/3#issuecomment-2509999589